### PR TITLE
Bump to fay 0.16

### DIFF
--- a/Language/Fay/Yesod.hs
+++ b/Language/Fay/Yesod.hs
@@ -9,7 +9,7 @@ import           Prelude
 #ifdef FAY
 import           FFI
 #else
-import           Language.Fay.FFI
+import           Fay.FFI
 #endif
 import           Data.Data
 

--- a/Yesod/Fay.hs
+++ b/Yesod/Fay.hs
@@ -100,7 +100,7 @@ import           Fay.Types                  (CompileConfig(..),
                                              configDirectoryIncludes,
                                              configTypecheck,
                                              configExportRuntime,
-                                             configNaked, CompileError)
+                                             CompileError)
 import           Language.Fay.Yesod         (Returns (Returns))
 import           Language.Haskell.TH.Syntax (Exp (LitE), Lit (StringL),
                                              Q,
@@ -312,7 +312,6 @@ fayFileProd settings = do
     qRunIO writeYesodFay
     eres <- qRunIO $ compileFayFile fp config
         { configExportRuntime = exportRuntime
-        , configNaked = not exportRuntime
         }
     case eres of
         Left e -> error $ "Unable to compile Fay module \"" ++ name ++ "\": " ++ show e
@@ -361,7 +360,6 @@ fayFileReload settings = do
         liftIO (compileFayFile (mkfp name) config
                 { configTypecheck = False
                 , configExportRuntime = exportRuntime
-                , configNaked = not exportRuntime
                 })
                 >>= \eres -> do
         (case eres of

--- a/sample/fay-shared/SharedTypes.hs
+++ b/sample/fay-shared/SharedTypes.hs
@@ -7,7 +7,7 @@ import Data.Data
 #ifdef FAY
 import FFI
 #else
-import Language.Fay.FFI
+import Fay.FFI
 #endif
 
 data Command = RollDie (Returns Text)

--- a/sample/fay/Language/Fay/JQuery.hs
+++ b/sample/fay/Language/Fay/JQuery.hs
@@ -6,7 +6,7 @@
 -- <https://github.com/faylang/fay-jquery/blob/master/Language/Fay/JQuery.hs>
 module Language.Fay.JQuery  where
 
-import Language.Fay.FFI
+import Fay.FFI
 import Language.Fay.Yesod
 
 data JQuery

--- a/yesod-fay.cabal
+++ b/yesod-fay.cabal
@@ -19,7 +19,7 @@ library
                        Language.Fay.Yesod
   other-modules:       Yesod.Fay.Data
   build-depends:       base >= 4 && < 5
-                     , fay  >= 0.14
+                     , fay  >= 0.16
                      , transformers >= 0.2
                      , aeson >= 0.6
                      , bytestring >= 0.9


### PR DESCRIPTION
I'll be uploading fay 0.16 shortly. The two changes I see that are needed in yesod-fay are renaming Language.Fay.FFI -> Fay.FFI and removing `configNaked` (declarations are at the top level by default now).

I only grepped and fixed these things, and made sure the package compiles. Let me know if there are any issues!

Unrelated to fay, there was also a compiler warning which I left in there since I'm not sure if it's kept for legacy support:

```
Yesod/Fay.hs:111:1:
    Warning: In the use of `jsonToRepJson'
             (imported from Yesod.Core, but defined in Yesod.Core.Json):
             Deprecated: "Use returnJson instead"
```

Cheers!
