### PR TITLE
Remove deprecated jsonToRepJson warning

### DIFF
--- a/Yesod/Fay.hs
+++ b/Yesod/Fay.hs
@@ -207,7 +207,7 @@ postFayCommandR =
                     Nothing -> error $ "Unable to parse input: " ++ show txt
                     Just cmd -> f go cmd
       where
-        go Returns = jsonToRepJson . showToFay
+        go Returns = returnJson . showToFay
 
 langYesodFay :: String
 langYesodFay = $(qRunIO $ fmap (LitE . StringL . unpack) $ readTextFile "Language/Fay/Yesod.hs")


### PR DESCRIPTION
A small change to get rid of the deprecation warning during compilation.
